### PR TITLE
Modified the regex for finding the trailer section to allow comment lines.

### DIFF
--- a/tcpdi_parser.php
+++ b/tcpdi_parser.php
@@ -405,7 +405,7 @@ class tcpdi_parser {
         unset($matches);
         $xref['max_object'] = max($xref['max_object'], $obj_num);
         // get trailer data
-        if (preg_match('/trailer[\s]*<<(.*)>>[\s]*[\r\n]+startxref[\s]*[\r\n]+/isU', $this->pdfdata, $matches, PREG_OFFSET_CAPTURE, $xoffset) > 0) {
+        if (preg_match('/trailer[\s]*<<(.*)>>[\s]*[\r\n]+(?:[%].*[\r\n]+)*startxref[\s]*[\r\n]+/isU', $this->pdfdata, $matches, PREG_OFFSET_CAPTURE, $xoffset) > 0) {
             $trailer_data = $matches[1][0];
             if (!isset($xref['trailer']) OR empty($xref['trailer'])) {
                 // get only the last updated version


### PR DESCRIPTION
Parser would previously raise an error if comment lines were placed in the trailer section before the startxref line.  Comment lines in the trailer section should now be accepted by the parser.