### PR TITLE
Fix Illegal string offset warnings

### DIFF
--- a/tcpdi_parser.php
+++ b/tcpdi_parser.php
@@ -721,8 +721,8 @@ class tcpdi_parser {
                 $next = strcspn($data, "\r\n", $offset);
                 if ($next > 0) {
                     $offset += $next;
-                    list($obj, $unused) = $this->getRawObject($offset, $data);
-                    return $obj;
+
+                    return $this->getRawObject($offset, $data);
                 }
                 break;
             }


### PR DESCRIPTION
If a pdf has such an object like the followings, `tcpdf_parser` fails to continue parsing the data. `getRawObject()` is expected to return an array which contains an object and its offset, but it currently returns an object without its offset if the pdf has `%` comments. It causes Illegal string offset warnings.


**PDF Object Sample**
```
2 0 obj
<< /Type /Page % 1
   /Parent 1 0 R
   /MediaBox [ 0 0 839.314286 1186.971429 ]
   /Contents 4 0 R
   /Group <<
      /Type /Group
      /S /Transparency
      /I true
      /CS /DeviceRGB
   >>
   /Resources 3 0 R
>>
```

**Warning Example**
```
Warning: Illegal string offset 'Parqaj' in /Users/lancelot/Sandbox/PHP/tcpdi_parser/tcpdi_parser/tcpdi_parser.php on line 712
PHP Warning:  Illegal string offset 'Parqak' in /Users/lancelot/Sandbox/PHP/tcpdi_parser/tcpdi_parser/tcpdi_parser.php on line 712
...
```