### PR TITLE
The path to tcpdf_filters.php can be parameterized

### DIFF
--- a/tcpdi_parser.php
+++ b/tcpdi_parser.php
@@ -48,7 +48,10 @@
  */
 
 // include class for decoding filters
-require_once(dirname(__FILE__).'/include/tcpdf_filters.php');
+if(defined('TCPDI_PARSER_FILTERS'))
+	require_once(TCPDI_PARSER_FILTERS);
+else 
+	require_once(dirname(__FILE__).'/include/tcpdf_filters.php');
 
 if (!defined ('PDF_TYPE_NULL'))
     define ('PDF_TYPE_NULL', 0);


### PR DESCRIPTION
If one installs [tecnickcom/TCPDF](https://packagist.org/packages/tecnickcom/tcpdf) with composer, one currently has to place tcpdf_filters.php explicitly into the directory tree of the library. This might be a problem during installation via composer and packaging. Furthermore it breaks with the concept of libraries as unmodifiable parts of third parties.

This change allows existing software to be run as before and adds the possibility to provide a custom location for the required script tcpdf_filters.php to tcpdi_parser.php.
